### PR TITLE
Fix Skylight login PKCE flow

### DIFF
--- a/Sources/SkylightBridge/Services/KeychainCredentialStore.swift
+++ b/Sources/SkylightBridge/Services/KeychainCredentialStore.swift
@@ -50,10 +50,20 @@ actor KeychainCredentialStore: CredentialStoring {
         if updateStatus == errSecSuccess {
             return
         }
+        if updateStatus == -25244 {
+            try delete(for: account)
+            try add(data, query: query)
+            return
+        }
+
         guard updateStatus == errSecItemNotFound else {
             throw error(for: updateStatus)
         }
 
+        try add(data, query: query)
+    }
+
+    private func add(_ data: Data, query: [CFString: Any]) throws {
         var attributes = query
         attributes[kSecValueData] = data
         attributes[kSecAttrAccessible] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly

--- a/Sources/SkylightBridge/Services/SkylightOAuthAuthenticator.swift
+++ b/Sources/SkylightBridge/Services/SkylightOAuthAuthenticator.swift
@@ -1,4 +1,6 @@
+import CryptoKit
 import Foundation
+import Security
 
 protocol SkylightOAuthTokenProvider: Sendable {
     func refresh(refreshToken: String) async throws -> SkylightOAuthToken
@@ -44,8 +46,9 @@ actor SkylightOAuthAuthenticator: SkylightOAuthTokenProvider {
     func login(email: String, password: String) async throws -> SkylightOAuthToken {
         let csrfToken = try await fetchCSRFToken()
         try await createSession(email: email, password: password, csrfToken: csrfToken)
-        let code = try await fetchAuthorizationCode()
-        return try await exchangeAuthorizationCode(code)
+        let pkce = try PKCEChallenge()
+        let code = try await fetchAuthorizationCode(pkce: pkce)
+        return try await exchangeAuthorizationCode(code, pkce: pkce)
     }
 
     func refresh(refreshToken: String) async throws -> SkylightOAuthToken {
@@ -117,13 +120,15 @@ actor SkylightOAuthAuthenticator: SkylightOAuthTokenProvider {
         }
     }
 
-    private func fetchAuthorizationCode() async throws -> String {
+    private func fetchAuthorizationCode(pkce: PKCEChallenge) async throws -> String {
         var components = URLComponents(url: authorizeURL, resolvingAgainstBaseURL: false)
         components?.queryItems = [
             URLQueryItem(name: "client_id", value: "skylight-mobile"),
             URLQueryItem(name: "response_type", value: "code"),
             URLQueryItem(name: "redirect_uri", value: "https://ourskylight.com/welcome"),
             URLQueryItem(name: "scope", value: "everything"),
+            URLQueryItem(name: "code_challenge", value: pkce.challenge),
+            URLQueryItem(name: "code_challenge_method", value: "S256"),
             URLQueryItem(
                 name: "skylight_api_client_device_fingerprint",
                 value: deviceFingerprint
@@ -177,10 +182,11 @@ actor SkylightOAuthAuthenticator: SkylightOAuthTokenProvider {
         return code
     }
 
-    private func exchangeAuthorizationCode(_ code: String) async throws -> SkylightOAuthToken {
+    private func exchangeAuthorizationCode(_ code: String, pkce: PKCEChallenge) async throws -> SkylightOAuthToken {
         try await postTokenForm([
             "grant_type": "authorization_code",
             "code": code,
+            "code_verifier": pkce.verifier,
             "client_id": "skylight-mobile",
             "redirect_uri": "https://ourskylight.com/welcome",
             "scope": "everything",
@@ -268,6 +274,30 @@ actor SkylightOAuthAuthenticator: SkylightOAuthTokenProvider {
             delegateQueue: nil
         )
         return SkylightURLSessionTransport(session: session)
+    }
+}
+
+private struct PKCEChallenge {
+    let verifier: String
+    let challenge: String
+
+    init() throws {
+        var bytes = Data(count: 32)
+        let status = bytes.withUnsafeMutableBytes { buffer in
+            SecRandomCopyBytes(kSecRandomDefault, buffer.count, buffer.baseAddress!)
+        }
+        guard status == errSecSuccess else {
+            throw LocalFileIntegrityError.randomGenerationFailed(status)
+        }
+        verifier = Self.base64URLEncoded(bytes)
+        challenge = Self.base64URLEncoded(Data(SHA256.hash(data: Data(verifier.utf8))))
+    }
+
+    private static func base64URLEncoded(_ data: Data) -> String {
+        data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
     }
 }
 

--- a/Tests/SkylightBridgeTests/SkylightAPIAuthenticationTests.swift
+++ b/Tests/SkylightBridgeTests/SkylightAPIAuthenticationTests.swift
@@ -103,6 +103,21 @@ struct SkylightAPIAuthenticationTests {
         ])
         #expect(requests[1].value(forHTTPHeaderField: "Cookie") == "session=first")
         #expect(requests[2].value(forHTTPHeaderField: "Cookie") == "session=second")
+        guard let authorizeURL = requests[2].url,
+              let authorizeItems = URLComponents(
+                url: authorizeURL,
+                resolvingAgainstBaseURL: false
+              )?.queryItems else {
+            Issue.record("Expected authorize request URL with query items")
+            return
+        }
+        #expect(authorizeItems.first { $0.name == "code_challenge_method" }?.value == "S256")
+        guard let codeChallenge = authorizeItems.first(where: { $0.name == "code_challenge" })?.value else {
+            Issue.record("Expected authorize request to include a PKCE code challenge")
+            return
+        }
+        #expect(!codeChallenge.isEmpty)
+        #expect(codeChallenge.allSatisfy { $0.isLetter || $0.isNumber || $0 == "-" || $0 == "_" })
 
         let loginForm = try formValues(from: requests[1])
         #expect(loginForm["authenticity_token"] == "csrf+token")
@@ -113,6 +128,12 @@ struct SkylightAPIAuthenticationTests {
         let tokenForm = try formValues(from: requests[3])
         #expect(tokenForm["grant_type"] == "authorization_code")
         #expect(tokenForm["code"] == "authorization-code")
+        guard let codeVerifier = tokenForm["code_verifier"] ?? nil else {
+            Issue.record("Expected token request to include a PKCE code verifier")
+            return
+        }
+        #expect(!codeVerifier.isEmpty)
+        #expect(codeVerifier.allSatisfy { $0.isLetter || $0.isNumber || $0 == "-" || $0 == "_" })
         #expect(tokenForm["skylight_api_client_device_fingerprint"] == "fingerprint")
     }
 


### PR DESCRIPTION
### Summary

Fixes first-time Skylight sign-in failing with:

Skylight sign-in did not return an authorization code (HTTP 400, expected a redirect).

Closes https://github.com/oliverames/skylight-bridge/issues/4

### What Changed

Skylight’s OAuth authorization flow now requires PKCE. The macOS app was requesting an authorization code without sending a code_challenge, so Skylight returned HTTP 400 instead of redirecting with a code.

This PR updates the login flow to:

• Generate a PKCE verifier and S256 challenge for each login attempt
• Send code_challenge and code_challenge_method=S256 on the authorize request
• Send the matching code_verifier during authorization-code token exchange
• Add test coverage verifying the PKCE authorize and token parameters

It also handles a first-login Keychain edge case where updating an existing credential item can fail with errSecInvalidOwnerEdit (-25244) by deleting and recreating the item.

### Testing

• Confirmed local Skylight login succeeds after the PKCE change
• Ran focused authentication tests successfully
• Ran Xcode build successfully during local validation

🤖 Generated with Codex